### PR TITLE
IPv6 and SSL support

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -2434,6 +2434,8 @@ sub irc_start {
             Server   => &config("server") || "irc.foonetic.net",
             Port     => &config("port") || "6667",
             Flood    => 0,
+            UseSSL   => &config("ssl") || 0,
+            useipv6  => &config("ipv6") || 0
         }
     );
 


### PR DESCRIPTION
I've added IPv6 and SSL support to Bucket. The IRC library already supports it, so I just had to add configuration options.
