### PR TITLE
"I" is case-sensitive when setting gender

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -1279,7 +1279,7 @@ sub irc_on_public {
             return;
         }
 
-        $target = $bag{who} if $target eq 'I';
+        $target = $bag{who} if uc $target eq 'I';
 
         if ($pronoun) {
             $gender = undef;


### PR DESCRIPTION
Currently, it's case-insensitive when determining whether to allow the change, but case-sensitive when determining the target, leading to this:

```
< yazdmich> bucket: what gender am i?
< Bucket> yazdmich: Grammatically, I refer to you as androgynous.  See http://wiki.xkcd.com/irc/Bucket#Docs for information on setting this.
< yazdmich> bucket: i am male
< Bucket> Okay, yazdmich
< yazdmich> bucket: what gender am i?
< Bucket> yazdmich: Grammatically, I refer to you as androgynous.  See http://wiki.xkcd.com/irc/Bucket#Docs for information on setting this.
<@Shrdlu> Bucket: what gender is i
< Bucket> Shrdlu: i is male.
```
