### PR TITLE
Excluding <reply> and <action> from random factoids

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -99,6 +99,7 @@ my %config_keys = (
     minimum_length           => [ i => 6 ],
     nickserv_msg             => [ s => "" ],
     nickserv_nick            => [ s => "NickServ" ],
+    random_exclude_verbs     => [ s => '<reply>,<action>'],
     random_item_cache_size   => [ i => 20 ],
     random_wait              => [ i => 3 ],
     repeated_queries         => [ i => 5 ],
@@ -2787,7 +2788,7 @@ sub heartbeat {
         chl  => $chl,
         who  => $nick,
         idle => 1,
-        exclude_verb => ['<reply>','<action>'],
+        exclude_verb => [split(',',&config("random_exclude_verbs"))],
     );
 }
 


### PR DESCRIPTION
Fixes #22 - accomplished by adding an exclude_verb param to lookup() to exclude a list of verbs from the search, then using it in the random-fact picker.  Spun up my own Bucket and tested him and it seems to be working just fine.  Feel free to hop into #fiveofoh and poke him - I set the random-fact timeout to 1 minute, so he should respond with a non-reply/action factoid within a minute, and I've put a few of each in my db.
