### PR TITLE
Don't spit out an error message if volunteering a factoid

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -1370,7 +1370,7 @@ sub irc_on_public {
                         &config("repeated_queries") )
                     {
                         Report
-"Volunteering a dump of '$bag{msg}' for $bag{who} in $chl";
+"Volunteering a dump of '$bag{msg}' for $bag{who} in $chl (if it exists)";
                         $_[KERNEL]->post(
                             db => 'MULTIPLE',
                             SQL =>
@@ -1382,6 +1382,7 @@ sub irc_on_public {
                                 cmd  => "literal",
                                 page => "*",
                                 fact => $bag{msg},
+                                ignore_empty => 1,
                             },
                             EVENT => 'db_success'
                         );
@@ -2244,7 +2245,9 @@ sub db_success {
         my @lines = ref $res->{RESULT} ? @{ $res->{RESULT} } : [];
 
         unless (@lines) {
-            &error( $bag{chl}, $bag{who}, "$bag{who}: " );
+            unless ( $bag{ignore_empty} ) {
+                &error( $bag{chl}, $bag{who}, "$bag{who}: " );
+            }
             return;
         }
 


### PR DESCRIPTION
Fixes #27.  Added a "ignore_empty" parameter to the baggage, set to 1 by the factoid-volunteering code.  The "literal" command handler then checks for this and is simply silent if it's set and there are no results.  Hat-tip to rcombs for the implementation idea.
