### PR TITLE
Don't volunteer non-existent factoid with repeated_queries ($addressed version)

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -506,6 +506,7 @@ sub irc_on_public {
                 cmd  => "literal",
                 page => $page,
                 fact => $fact,
+                addressed => $addressed,
             },
             EVENT => 'db_success'
         );
@@ -1370,7 +1371,7 @@ sub irc_on_public {
                         &config("repeated_queries") )
                     {
                         Report
-"Volunteering a dump of '$bag{msg}' for $bag{who} in $chl";
+"Volunteering a dump of '$bag{msg}' for $bag{who} in $chl (if it exists)";
                         $_[KERNEL]->post(
                             db => 'MULTIPLE',
                             SQL =>
@@ -2244,7 +2245,9 @@ sub db_success {
         my @lines = ref $res->{RESULT} ? @{ $res->{RESULT} } : [];
 
         unless (@lines) {
-            &error( $bag{chl}, $bag{who}, "$bag{who}: " );
+            if ( $bag{addressed} ) {
+                &error( $bag{chl}, $bag{who}, "$bag{who}: " );
+            }
             return;
         }
 


### PR DESCRIPTION
Same functionality as PR #32, but this time setting $addressed on user-generated `literal` queries, so it functions as a filter for whether or not to spit out an error (since the repeated_queries generated version won't have $addressed set).  In my testing, works identically to the other version.
