### PR TITLE
Fix Unicode!

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -2953,6 +2953,9 @@ sub do {
     my $chl    = shift;
     my $action = "@_";
 
+    utf8::encode( $chl ) if utf8::is_utf8( $chl );
+    utf8::encode( $action ) if utf8::is_utf8( $action );
+
     my %data = ( chl => $chl, text => $action );
     return if &signal_plugin( "do", \%data );
     ( $chl, $action ) = ( $data{chl}, $data{text} );


### PR DESCRIPTION
This should fix the mysterious broken-Unicode bug seen in #xkcd.

It turns out that _sometimes_ the channel name (`$chl`) has the utf8 flag set, causing `$text` to be interpreted wrongly (blindly casted to utf8) when they are finally concatenated.

Tested with Perl 5.20. (Requires at least Perl 5.8.1 for `utf8::is_utf8()`.)
