### PR TITLE
Don't allow setting server_pass from IRC

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -99,7 +99,6 @@ my %config_keys = (
     random_item_cache_size   => [ i => 20 ],
     random_wait              => [ i => 3 ],
     repeated_queries         => [ i => 5 ],
-    server_pass              => [ s => '' ],
     timeout                  => [ i => 60 ],
     the_fucking              => [ p => 100 ],
     tumblr_name              => [ p => 50 ],


### PR DESCRIPTION
Any bot op could get or set the server password with e.g. "Bucket: get server_pass", which is not a good thing.

I didn't intend to introduce this possibility, but I guess I just never noticed it was there in the output of "Bucket: set" until now. Sorry, @zigdon!