### PR TITLE
Add flood_control option: 1 = on, 0 = off

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -2389,7 +2389,7 @@ sub irc_start {
             Server   => &config("server") || "irc.foonetic.net",
             Port     => &config("port") || "6667",
             Password => &config("server_pass") || "",
-            Flood    => 0,
+            Flood    => ( &config("flood_control") ? 0 : 1 ),
             UseSSL   => &config("ssl") || 0,
             useipv6  => &config("ipv6") || 0,
             LocalAddr => &config("local_address")


### PR DESCRIPTION
Of course, POE::Component::IRC uses 0 to mean on and 1 to mean off, so
needs a little logical reversal to work (provided).

This is useful for people who might use Bucket behind a bouncer and want to
let the bouncer take care of flood protection.