### PR TITLE
Refill large var cache even for special cases

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -3235,7 +3235,7 @@ sub expand {
             $replacement = A($replacement) if $2;
 
             if ( exists $record->{cache} and not @{$record->{cache}} ) {
-                Log "Refilling cache for $full";
+                Log "Refilling cache for $var";
                 &sql(
                     'select vars.id id, name, perms, type, value
                       from bucket_vars vars
@@ -3244,7 +3244,7 @@ sub expand {
                       where name = ?
                       order by rand()
                       limit 20',
-                    [$full],
+                    [$var],
                     {cmd => "load_vars_large", db_type => 'MULTIPLE'}
                 );
             }


### PR DESCRIPTION
Cache refill needs to use $var, not $full, so the effects of any substitutions
are used when querying the DB. This prevents trying to query for values of e.g.
"$verbing" instead of "$verb".

Been testing for a few days and haven't noticed any more empty substitutions like we discussed on IRC, @zigdon. I think it's fixed.