### PR TITLE
Use &say_long for 'list vars' to avoid truncation

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -985,7 +985,7 @@ sub irc_on_public {
             &say( $chl => "Sorry, $bag{who}, there are no defined variables!" );
             return;
         }
-        &say(
+        &say_long(
             $chl => "Known variables:",
             &make_list(
                 map {


### PR DESCRIPTION
Fixes managing vars for bots with lots of them. Presumably Bucket has fewer variables than my bot does, and has never run into this problem.