### PR TITLE
Strip colon-terminated line prefix only if followed by space

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -302,7 +302,7 @@ sub irc_on_public {
         $bag{addressed} = 1;
         $bag{to}        = $nick;
     } else {
-        $bag{msg} =~ s/^(\S+):\s*//;
+        $bag{msg} =~ s/^(\S+):\s+//;
         $bag{to} = $1;
     }
 


### PR DESCRIPTION
Alleviates some of #76, but only for keywords like "Re:Zero".
Does not help for keywords like "Re: Zero".

This implements the main fix I suggested, but does not close the issue as it might yet be desired to fix this completely and allow triggers of the form `Word: More Words`.

As far as testing, this has been running in my production instance probably since mid-June. It's been so long that I forgot when I actually added it.