### PR TITLE
Verify that $to exists before stripping it from the line

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -302,8 +302,13 @@ sub irc_on_public {
         $bag{addressed} = 1;
         $bag{to}        = $nick;
     } else {
+        my $orig_msg = $bag{msg};
         $bag{msg} =~ s/^(\S+):\s*//;
-        $bag{to} = $1;
+        if( &nick_in_chan($1, $chl) ) {
+            $bag{to} = $1;
+        } else {
+            $bag{msg} = $orig_msg;
+        }
     }
 
     $bag{op} = 0;
@@ -2768,6 +2773,14 @@ sub someone {
 
     return 'someone' unless keys %nicks;
     return ( values %nicks )[ rand( keys %nicks ) ];
+}
+
+sub nick_in_chan {
+    my $nick = lc shift;
+    my $channel = shift;
+    my %nicks   = map { lc $_ => $_ } keys %{$stats{users}{$channel}};
+
+    return exists $nicks{$nick};
 }
 
 sub clear_cache {

--- a/bucket.pl
+++ b/bucket.pl
@@ -302,14 +302,9 @@ sub irc_on_public {
         $bag{addressed} = 1;
         $bag{to}        = $nick;
     } else {
-        my $orig_msg = $bag{msg};
-        $bag{msg} =~ s/^(\S+):\s*//;
-        if( defined($1) ) {
-            if( $irc->is_channel_member( $bag{chl}, $1 ) ) {
-                $bag{to} = $1;
-            } else {
-                $bag{msg} = $orig_msg;
-            }
+        if( $bag{msg} =~ m/^(\S+):\s*/ and $irc->is_channel_member( $bag{chl}, $1 ) ) {
+            $bag{msg} =~ s/^(\S+):\s*//;
+            $bag{to} = $1;
         }
     }
 

--- a/bucket.pl
+++ b/bucket.pl
@@ -304,10 +304,12 @@ sub irc_on_public {
     } else {
         my $orig_msg = $bag{msg};
         $bag{msg} =~ s/^(\S+):\s*//;
-        if( &nick_in_chan($1, $chl) ) {
-            $bag{to} = $1;
-        } else {
-            $bag{msg} = $orig_msg;
+        if( defined($1) ) {
+            if( $irc->is_channel_member( $bag{chl}, $1 ) ) {
+                $bag{to} = $1;
+            } else {
+                $bag{msg} = $orig_msg;
+            }
         }
     }
 
@@ -2773,14 +2775,6 @@ sub someone {
 
     return 'someone' unless keys %nicks;
     return ( values %nicks )[ rand( keys %nicks ) ];
-}
-
-sub nick_in_chan {
-    my $nick = lc shift;
-    my $channel = shift;
-    my %nicks   = map { lc $_ => $_ } keys %{$stats{users}{$channel}};
-
-    return exists $nicks{$nick};
 }
 
 sub clear_cache {


### PR DESCRIPTION
Resolves #76 in most cases—except if the factoid that can't be triggered begins with a `nick:` highlight where the `nick` exists on the channel.

It would be possible to have the factoid search look for the incoming line both with and without the prefix, preferring the result set with the prefix if it is non-empty…but that's much more work for minimal benefit. (Future visitors to this repository can feel free to revive the discussion on #76, or open a new issue, if the lack of this functionality causes problems.)