### PR TITLE
Add plugin signal for when no factoids/functions match

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -1623,9 +1623,12 @@ sub db_success {
                 &error( $bag{chl}, $bag{who} );
             }
             return;
-        } elsif ( $bag{addressed} ) {
-            &error( $bag{chl}, $bag{who} );
-            return;
+        } else {
+            return if &signal_plugin( "empty_lookup", \%bag );
+            if ( $bag{addressed} ) {
+                &error( $bag{chl}, $bag{who} );
+                return;
+            }
         }
 
         #Log "extra work on $bag{msg}";

--- a/plugins/README
+++ b/plugins/README
@@ -11,6 +11,7 @@ Bucket plugins:
 - Known signals:
   - "db_success", { bag, res }               - called after database lookups
   - "do", { chl, text }                      - on OUR action
+  - "empty_lookup", \%bag                    - when no bot functions match an incoming line
   - "get_stats", { text_ref }                - when generating the stats text
   - "heartbeat", {}                          - called on a regular interval
   - "jointopic", { chl, topic }              - topic upon joining a channel

--- a/plugins/README
+++ b/plugins/README
@@ -11,7 +11,7 @@ Bucket plugins:
 - Known signals:
   - "db_success", { bag, res }               - called after database lookups
   - "do", { chl, text }                      - on OUR action
-  - "empty_lookup", \%bag                    - when no bot functions match an incoming line
+  - "empty_lookup", \%bag                    - an incoming line (addressed or not) matched nothing
   - "get_stats", { text_ref }                - when generating the stats text
   - "heartbeat", {}                          - called on a regular interval
   - "jointopic", { chl, topic }              - topic upon joining a channel


### PR DESCRIPTION
Intended to make it possible for plugins to intercept e.g. "don't know" being fired, but hopefully has broader applications than the original idea of adding a signal in `elsif ( $bag{addressed} )`.

I will use this PR to quickly pull the new signal into my production instance and start toying with writing a plugin that uses it. Will merge if it serves the purpose correctly, and make changes if not.