### PR TITLE
Add pre_expand signal for filtering tidbits

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -3063,6 +3063,8 @@ sub sql {
 sub expand {
     my ( $who, $chl, $msg, $editable, $to ) = @_;
 
+    return if &signal_plugin( "pre_expand", {tidbit => \$msg} );
+
     my $gender = $stats{users}{genders}{lc $who};
     my $target = $who;
     while ( $msg =~ /(?<!\\)(\$who\b|\${who})/i ) {

--- a/plugins/README
+++ b/plugins/README
@@ -27,6 +27,7 @@ Bucket plugins:
   - "on_notice", { who, msg }                - when seeing a notice
   - "on_public", \%bag                       - on public messages
   - "on_topic": { chl, topic }               - when topic is changed
+  - "pre_expand": { \$msg }                  - before variables are interpolated in tidbit
   - "say", { chl, text }                     - when WE say anything
   - "start", {}                              - called on boot
 


### PR DESCRIPTION
New signal called before expanding variables in a factoid. The tidbit itself is passed in as a reference.

Added for use by my plugin that implements the new syntax described in #89.