### PR TITLE
Minor fixups for newer versions of MySQL and Perl

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -3065,24 +3065,24 @@ sub expand {
 
     my $gender = $stats{users}{genders}{lc $who};
     my $target = $who;
-    while ( $msg =~ /(?<!\\)(\$who\b|\${who})/i ) {
+    while ( $msg =~ /(?<!\\)(\$who\b|\$\{who\})/i ) {
         my $cased = &set_case( $1, $who );
-        last unless $msg =~ s/(?<!\\)(?:\$who\b|\${who})/$cased/i;
+        last unless $msg =~ s/(?<!\\)(?:\$who\b|\$\{who\})/$cased/i;
         $stats{last_vars}{$chl}{who} = $who;
     }
 
-    while ( $msg =~ /(?<!\\)(\$channel\b|\${channel})/i ) {
+    while ( $msg =~ /(?<!\\)(\$channel\b|\$\{channel\})/i ) {
         my $cased = &set_case( $1, $chl );
-        last unless $msg =~ s/(?<!\\)(?:\$channel\b|\${channel})/$cased/i;
+        last unless $msg =~ s/(?<!\\)(?:\$channel\b|\$\{channel\})/$cased/i;
         $stats{last_vars}{$chl}{channel} = $chl;
     }
 
-    if ( $msg =~ /(?<!\\)(?:\$someone\b|\${someone})/i ) {
+    if ( $msg =~ /(?<!\\)(?:\$someone\b|\$\{someone\})/i ) {
         $stats{last_vars}{$chl}{someone} = [];
-        while ( $msg =~ /(?<!\\)(\$someone\b|\${someone})/i ) {
+        while ( $msg =~ /(?<!\\)(\$someone\b|\$\{someone\})/i ) {
             my $rnick = &someone( $chl, $who, defined $to ? $to : () );
             my $cased = &set_case( $1, $rnick );
-            last unless $msg =~ s/\$someone\b|\${someone}/$cased/i;
+            last unless $msg =~ s/\$someone\b|\$\{someone\}/$cased/i;
             push @{$stats{last_vars}{$chl}{someone}}, $rnick;
 
             $gender = $stats{users}{genders}{lc $rnick};
@@ -3090,12 +3090,12 @@ sub expand {
         }
     }
 
-    while ( $msg =~ /(?<!\\)(\$to\b|\${to})/i ) {
+    while ( $msg =~ /(?<!\\)(\$to\b|\$\{to\})/i ) {
         unless ( defined $to ) {
             $to = &someone( $chl, $who );
         }
         my $cased = &set_case( $1, $to );
-        last unless $msg =~ s/(?<!\\)(?:\$to\b|\${to})/$cased/i;
+        last unless $msg =~ s/(?<!\\)(?:\$to\b|\$\{to\})/$cased/i;
         push @{$stats{last_vars}{$chl}{to}}, $to;
 
         $gender = $stats{users}{genders}{lc $to};
@@ -3103,7 +3103,7 @@ sub expand {
     }
 
     $stats{last_vars}{$chl}{item} = [];
-    while ( $msg =~ /(?<!\\)(\$(give)?item|\${(give)?item})/i ) {
+    while ( $msg =~ /(?<!\\)(\$(give)?item|\$\{(give)?item\})/i ) {
         my $giveflag = $2 || $3 ? "give" : "";
         if (@inventory) {
             my $give  = $editable && $giveflag;
@@ -3113,10 +3113,10 @@ sub expand {
               $give ? "$item (given)" : $item;
             last
               unless $msg =~
-              s/(?<!\\)(?:\$${giveflag}item|\${${giveflag}item})/$cased/i;
+              s/(?<!\\)(?:\$${giveflag}item|\$\{${giveflag}item\})/$cased/i;
         } else {
             $msg =~
-              s/(?<!\\)(?:\$${giveflag}item|\${${giveflag}item})/bananas/i;
+              s/(?<!\\)(?:\$${giveflag}item|\$\{${giveflag}item\})/bananas/i;
             push @{$stats{last_vars}{$chl}{item}}, "(bananas)";
         }
     }
@@ -3124,7 +3124,7 @@ sub expand {
       unless @{$stats{last_vars}{$chl}{item}};
 
     $stats{last_vars}{$chl}{newitem} = [];
-    while ( $msg =~ /(?<!\\)(\$(new|get)item|\${(new|get)item})/i ) {
+    while ( $msg =~ /(?<!\\)(\$(new|get)item|\$\{(new|get)item\})/i ) {
         my $keep = lc( $2 || $3 );
         if ($editable) {
             my $newitem = shift @random_items || 'bananas';
@@ -3146,10 +3146,10 @@ sub expand {
             my $cased = &set_case( $1, $newitem );
             last
               unless $msg =~
-              s/(?<!\\)(?:\$${keep}item|\${${keep}item})/$cased/i;
+              s/(?<!\\)(?:\$${keep}item|\$\{${keep}item\})/$cased/i;
             push @{$stats{last_vars}{$chl}{newitem}}, $newitem;
         } else {
-            $msg =~ s/(?<!\\)(?:\$${keep}item|\${${keep}item})/bananas/ig;
+            $msg =~ s/(?<!\\)(?:\$${keep}item|\$\{${keep}item\})/bananas/ig;
         }
     }
     delete $stats{last_vars}{$chl}{newitem}
@@ -3157,7 +3157,7 @@ sub expand {
 
     if ($gender) {
         foreach my $gvar ( keys %gender_vars ) {
-            next unless $msg =~ /(?<!\\)(?:\$$gvar\b|\${$gvar})/i;
+            next unless $msg =~ /(?<!\\)(?:\$$gvar\b|\$\{$gvar\})/i;
 
             Log "Replacing gvar $gvar...";
             if ( exists $gender_vars{$gvar}{$gender} ) {
@@ -3167,7 +3167,7 @@ sub expand {
                     $g_v =~ s/%N/$target/;
                     Log " => $g_v";
                 }
-                while ( $msg =~ /(?<!\\)(\$$gvar\b|\${$gvar})/i ) {
+                while ( $msg =~ /(?<!\\)(\$$gvar\b|\$\{$gvar\})/i ) {
                     my $cased = &set_case( $1, $g_v );
                     last unless $msg =~ s/\Q$1/$cased/g;
                 }
@@ -3181,7 +3181,7 @@ sub expand {
     my $oldmsg = "";
     $stats{last_vars}{$chl} = {};
     while ( $oldmsg ne $msg
-        and $msg =~ /(?<!\\)(?:\$([a-zA-Z_]\w+)|\${([a-zA-Z_]\w+)})/ )
+        and $msg =~ /(?<!\\)(?:\$([a-zA-Z_]\w+)|\$\{([a-zA-Z_]\w+)\})/ )
     {
         $oldmsg = $msg;
         my $var = $1 || $2;

--- a/bucket.sql
+++ b/bucket.sql
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS `bucket_facts` (
   `fact` varchar(128) NOT NULL,
   `tidbit` text NOT NULL,
   `verb` varchar(16) NOT NULL default 'is',
-  `RE` tinyint(1) NOT NULL,
+  `RE` tinyint(1) NOT NULL default 0,
   `protected` tinyint(1) NOT NULL,
   `mood` tinyint(3) unsigned default NULL,
   `chance` tinyint(3) unsigned default NULL,


### PR DESCRIPTION
Migrated my bucket clone to a newer system, ran in to some headaches due to newer MySQL and Perl versions. 

MySQL STRICT_TRANS_TABLES was causing issues when setting factiods.  RE field was not being set by bucket.pl and therefore MySQL just dropped the transaction.  If RE is set to have a default value, this is not a problem.

Perl was complaining about unescaped left braces on a number of regex lines.  I guess this was deprecated at some point.