### PR TITLE
Remove unnecessary prefix stripping in quotes plugin

### DIFF
--- a/plugins/plugin.quotes.pl
+++ b/plugins/plugin.quotes.pl
@@ -155,7 +155,6 @@ sub quote {
     }
 
     my $quote;
-    $match->[2] =~ s/^(?:\S+:)? +//;
     if ( $match->[1] eq 'irc_ctcp_action' ) {
         $quote = "* $match->[0] $match->[2]";
     } else {


### PR DESCRIPTION
Bucket core already does this before signaling. Having the quotes plugin do it again just results in broken quotes if the line begins with a single word and a colon. Resolves #28.