### PR TITLE
Item deletion message: destroy -> delete

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -520,7 +520,7 @@ sub irc_on_public {
             &say( $chl => "Sorry, $bag{who}, I can't find that!" );
             return;
         }
-        &say( $chl => "Okay, $bag{who}, destroying '$item'" );
+        &say( $chl => "Okay, $bag{who}, deleting item '$item'" );
         @inventory = grep { $_ ne $item } @inventory;
         &sql( "delete from bucket_items where `what` = ?", [$item] );
         delete $stats{detailed_inventory}{$bag{who}}[$num];


### PR DESCRIPTION
Change the confirmation for item deletion from "destroying $item" to "deleting item $item", which is more consistent with the command used to do so ("delete item #20"). The last few times I've wanted to delete an item it took me three tries to get there ("destroy item #20", "destroy #20") and I feel this might help.

(augh, sorry about the branch name. Editing through the Github interface, should've caught that earlier)