### PR TITLE
Allow : and , as the separator when channel denizens addressed

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -302,8 +302,8 @@ sub irc_on_public {
         $bag{addressed} = 1;
         $bag{to}        = $nick;
     } else {
-        if( $bag{msg} =~ m/^(\S+):\s*/ and $irc->is_channel_member( $bag{chl}, $1 ) ) {
-            $bag{msg} =~ s/^(\S+):\s*//;
+        if( $bag{msg} =~ m/^(\S+)[:,]\s*/ and $irc->is_channel_member( $bag{chl}, $1 ) ) {
+            $bag{msg} =~ s/^(\S+)[:,]\s*//;
             $bag{to} = $1;
         }
     }


### PR DESCRIPTION
I think this also affects the result of some quote operations, but I don't think that's really a problem. The net result is that I can say `barometz, bucket.pl` to trigger the `bucket.pl` factoid, same as when I say `Bucket, bucket.pl`.