### PR TITLE
Refer errors to GitHub issues as well as Zigdon

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -725,8 +725,9 @@ sub irc_on_public {
                 );
             } else {
                 &say( $chl =>
-                        "Sorry, $bag{who}, that's an invalid undo structure."
-                      . "  Tell Zigdon, please." );
+                        "Sorry, $bag{who}, that's an invalid undo structure. "
+                      . "Please tell Zigdon, or report the command used at "
+                      . "https://github.com/zigdon/xkcd-Bucket/issues/new" );
             }
 
         } elsif ( $undo->[0] eq 'edit' ) {
@@ -758,8 +759,9 @@ sub irc_on_public {
                 &say( $chl => "Okay, $bag{who}, undone $undo->[3]." );
             } else {
                 &say( $chl =>
-                        "Sorry, $bag{who}, that's an invalid undo structure."
-                      . "  Tell Zigdon, please." );
+                        "Sorry, $bag{who}, that's an invalid undo structure. "
+                      . "Please tell Zigdon, or report the command used at "
+                      . "https://github.com/zigdon/xkcd-Bucket/issues/new" );
             }
             delete $undo{$uchannel};
         } else {


### PR DESCRIPTION
For instances of Bucket other than the main one, users may have no idea who Zigdon is or how to contact him, because they are on a different IRC network. Linking to Bucket's GitHub issue tracker will make getting a report of these errors more likely.

Happened to notice these error messages while reading through the code to work on another issue.