### PR TITLE
Remove unreachable "I am" code in &db_success

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -1508,9 +1508,6 @@ sub db_success {
             if ( $fact eq 'you' and $verb eq 'are' ) {
                 $fact = $nick;
                 $verb = "is";
-            } elsif ( $fact eq 'I' and $verb eq 'am' ) {
-                $fact = $bag{who};
-                $verb = "is";
             }
 
             $stats{learn}++;


### PR DESCRIPTION
See #69. Bucket doesn't actually seem to learn from someone saying, "Bucket, I am a tester." for example. Even if it was picked up, code later in that function would reject learning such a factoid ("Please don't edit your own factoids, $bag{who}."). So this check is pointless.