### PR TITLE
join/part: Let channel names be any non-whitespace

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -611,7 +611,7 @@ sub irc_on_public {
         &talking( $chl, -1 );
     } elsif ( $addressed
         and $operator
-        and $bag{msg} =~ /^(join|part) (#[-\w]+)(?: (.*))?/i )
+        and $bag{msg} =~ /^(join|part) (#\S+)(?: (.*))?/i )
     {
         my ( $cmd, $dst, $msg ) = ( $1, $2, $3 );
         unless ($dst) {


### PR DESCRIPTION
Fixes #73.

For now, we'll continue to assume that channel names always start with `#`.