### PR TITLE
Selectively prune gender cache on PART and KICK

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -273,6 +273,10 @@ sub irc_on_kick {
     );
 
     delete $stats{users}{$chl}{$kickee};
+
+    if ( !@{$irc->nick_channels( $kickee )} ) {
+        delete $stats{users}{genders}{lc $who};
+    }
 }
 
 sub irc_on_quit {
@@ -2516,7 +2520,9 @@ sub irc_on_part {
 
     delete $stats{users}{$chl}{$who};
 
-    delete $stats{users}{genders}{lc $who};
+    if ( !@{$irc->nick_channels( $who )} ) {
+        delete $stats{users}{genders}{lc $who};
+    }
 }
 
 sub irc_on_chan_sync {


### PR DESCRIPTION
On PART, prune the user's cached gender only if Bucket no longer shares any channels with them.

KICK did not prune the gender cache at all before, but it now follows the same (new) logic as PART.