### PR TITLE
Fix undefined local `$who` in gender cache pruning

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -276,7 +276,7 @@ sub irc_on_kick {
     delete $stats{users}{$chl}{$kickee};
 
     if ( !@{$irc->nick_channels( $kickee )} ) {
-        delete $stats{users}{genders}{lc $who};
+        delete $stats{users}{genders}{lc $kickee};
     }
 }
 


### PR DESCRIPTION
Had trouble with this line when trying to set up a fresh Bucket instance tonight.

Patch in 304dc4948a5fa20c82f413ffcbac28fc67a59bab (from #129) was slightly under tested, I guess. Whoops.

Sorry y'all. But nobody opened an issue for it in two years, so maybe there are even fewer Bucket users left than I thought. 😅