### PR TITLE
Try to fix parts/quits now causing Bucket to crash

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -275,7 +275,7 @@ sub irc_on_kick {
 
     delete $stats{users}{$chl}{$kickee};
 
-    if ( !@{$irc->nick_channels( $kickee )} ) {
+    if ( !@{$irc->nick_channels( $kickee ) // []} ) {
         delete $stats{users}{genders}{lc $kickee};
     }
 }
@@ -2521,7 +2521,7 @@ sub irc_on_part {
 
     delete $stats{users}{$chl}{$who};
 
-    if ( !@{$irc->nick_channels( $who )} ) {
+    if ( !@{$irc->nick_channels( $who ) // []} ) {
         delete $stats{users}{genders}{lc $who};
     }
 }


### PR DESCRIPTION
Someone parting or getting kicked now causes Bucket to crash with an error about treating an undefined value as an ARRAY reference.

I can only assume some subtle behavior changes have happened in the years and Perl versions since I last ran this code, and something that used to be allowed is no longer kosher. There were no issues initially with #129 (where these `if` blocks came from) or I'm positive I wouldn't have merged the patch.