### PR TITLE
Fix updating genders on MySQL 8-like clients

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -1292,8 +1292,8 @@ sub irc_on_public {
 
         Log "$bag{who} set ${target}'s gender to $gender";
         $stats{users}{genders}{lc $target} = lc $gender;
-        &sql( "replace genders (nick, gender, stamp) values (?, ?, ?)",
-            [ $target, $gender, undef ] );
+        &sql( "replace genders (nick, gender) values (?, ?)",
+            [ $target, $gender ] );
         &say( $chl => "Okay, $bag{who}" );
     } elsif ( $addressed
         and $bag{msg} =~ /^what is my gender\??$|^what gender am I\??/i )

--- a/bucket.sql
+++ b/bucket.sql
@@ -102,7 +102,7 @@ CREATE TABLE IF NOT EXISTS `genders` (
   `id` int(10) unsigned NOT NULL auto_increment,
   `nick` varchar(30) NOT NULL,
   `gender` enum('male','female','Androgynous','inanimate','full name') NOT NULL default 'Androgynous',
-  `stamp` timestamp NOT NULL default CURRENT_TIMESTAMP,
+  `stamp` timestamp NOT NULL default CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `nick` (`nick`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=latin1;


### PR DESCRIPTION
I'm running Bucket on a PlanetScale database now, which aims to be MySQL 8 compatible. (It lets me avoid having to manage MySQL hosting myself on my silly little VPS.)

Upstream MySQL 8 has deprecated the behavior where inserting/updating a TIMESTAMP column with NULL uses the DEFAULT. PlanetScale emulates this, of course, and trying to e.g. `Bucket, I am male` yields an error:
`Column 'stamp' cannot be null (errno 1048) (sqlstate 23000)`

To apply the SQL schema change from this patch to an existing database, run this query:

```sql
ALTER TABLE `genders` MODIFY COLUMN `stamp` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp();
```