### PR TITLE
Different approach to the can't-use-string-as-array-ref bug

### DIFF
--- a/bucket.pl
+++ b/bucket.pl
@@ -275,7 +275,7 @@ sub irc_on_kick {
 
     delete $stats{users}{$chl}{$kickee};
 
-    if ( !@{$irc->nick_channels( $kickee ) // []} ) {
+    unless ( $irc->nick_channels( $kickee ) ) {
         delete $stats{users}{genders}{lc $kickee};
     }
 }
@@ -2521,7 +2521,7 @@ sub irc_on_part {
 
     delete $stats{users}{$chl}{$who};
 
-    if ( !@{$irc->nick_channels( $who ) // []} ) {
+    unless ( $irc->nick_channels( $who ) ) {
         delete $stats{users}{genders}{lc $who};
     }
 }


### PR DESCRIPTION
Quick test shows that this doesn't cause a crash under the same conditions, but I'm also not positive that the problem was consistently triggered so this is 50% a stab in the dark.

I'll run this patch in my Bucket bot for a while and see if it continues randomly quitting when people quit/get kicked.